### PR TITLE
feat(File Encoding): Added toggle for single byte encoding

### DIFF
--- a/src/app/components/settings-modal/settings-modal.component.ts
+++ b/src/app/components/settings-modal/settings-modal.component.ts
@@ -203,8 +203,8 @@ export class SettingsModalComponent implements OnInit {
         label: 'List Delimiter',
         required: true,
         description: 'Used to separate individual values in a single field when that field supports multiple values. ' +
-        'For example, when listDeliminator=;, multiple categories can be specified as: A;B;C. Commas can also be used ' +
-        'as the list delimiter value, provided quotes are used around the value, such as: "A,B,C".',
+          'For example, when listDeliminator=;, multiple categories can be specified as: A;B;C. Commas can also be used ' +
+          'as the list delimiter value, provided quotes are used around the value, such as: "A,B,C".',
         sortOrder: 31,
       }, {
         name: 'dateFormat',
@@ -212,19 +212,32 @@ export class SettingsModalComponent implements OnInit {
         label: 'Date Format',
         required: true,
         description: 'Default value is MM/dd/yy HH:mm. ' +
-        'Documentation: http://docs.oracle.com/javase/8/docs/api/java/text/SimpleDateFormat.html',
+          'Documentation: http://docs.oracle.com/javase/8/docs/api/java/text/SimpleDateFormat.html',
         sortOrder: 32,
       }, {
         name: 'processEmptyAssociations',
         type: 'tiles',
         label: 'Process Empty Associations',
         required: true,
-        description: 'If set to true then all To-Many association cells that are empty will remove any existing associations. ' +
-        'Default value is false, which will ignore the empty cells.',
+        description: 'If Yes then all To-Many association cells that are empty will remove any existing associations. ' +
+          'Defaults to No, which will ignore empty cells.',
         options: [
           { label: 'Yes', value: true },
           { label: 'No', value: false }],
         sortOrder: 33,
+      }, {
+        name: 'singleByteEncoding',
+        type: 'tiles',
+        label: 'Single Byte Encoding',
+        required: true,
+        description: 'If Yes then CSV files will be read in using the ISO-8859-1 (single-byte) encoding. ' +
+          'Defaults to No, which will read in CVS files using the UTF-8 (multi-byte) encoding. ' +
+          'The single byte encoding covers only latin characters and some accented characters while ' +
+          'UTF-8 covers all characters from all languages.',
+        options: [
+          { label: 'Yes', value: true },
+          { label: 'No', value: false }],
+        sortOrder: 34,
       }, {
         name: 'numThreads',
         type: 'number',

--- a/src/app/providers/file/file.service.fakes.ts
+++ b/src/app/providers/file/file.service.fakes.ts
@@ -81,6 +81,7 @@ export class FileServiceFakes {
     listDelimiter: ';',
     dateFormat: 'MM/dd/yyyy',
     processEmptyAssociations: false,
+    singleByteEncoding: false,
     numThreads: 15,
     existFields: [{
       entity: 'Candidate',

--- a/src/app/providers/file/file.service.ts
+++ b/src/app/providers/file/file.service.ts
@@ -19,7 +19,7 @@ import { ISettings } from '../../../interfaces/ISettings';
 @Injectable()
 export class FileService {
   // The version of the settings file to use for backwards compatibility breaking changes
-  static SETTINGS_FILE_VERSION: number = 2;
+  static SETTINGS_FILE_VERSION: number = 3;
 
   private defaultConfig: IConfig = {
     onboarded: false,
@@ -32,6 +32,7 @@ export class FileService {
     dataCenter: 'bhnext',
     listDelimiter: ';',
     processEmptyAssociations: false,
+    singleByteEncoding: false,
     dateFormat: 'MM/dd/yy HH:mm',
     authorizeUrl: 'https://auth9.bullhornstaffing.com/oauth/authorize',
     tokenUrl: 'https://auth9.bullhornstaffing.com/oauth/token',
@@ -100,6 +101,10 @@ export class FileService {
           // Default processEmptyAssociations before version 2
           if (!settings.version || settings.version < 2) {
             settings.processEmptyAssociations = false;
+          }
+          // Default singleByteEncoding before version 3
+          if (!settings.version || settings.version < 3) {
+            settings.singleByteEncoding = false;
           }
           return settings;
         } catch (parseErr) {

--- a/src/app/utils/utils.ts
+++ b/src/app/utils/utils.ts
@@ -27,6 +27,7 @@ export class Utils {
     args = args.concat(['listDelimiter', settings.listDelimiter]);
     args = args.concat(['dateFormat', settings.dateFormat]);
     args = args.concat(['processEmptyAssociations', settings.processEmptyAssociations ? 'true' : 'false']);
+    args = args.concat(['singleByteEncoding', settings.singleByteEncoding ? 'true' : 'false']);
     args = args.concat(['numThreads', settings.numThreads.toString()]);
     args = args.concat(['resultsFileEnabled', 'true']);
     args = args.concat(['resultsFilePath', resultsFilePath]);

--- a/src/interfaces/ISettings.ts
+++ b/src/interfaces/ISettings.ts
@@ -18,5 +18,6 @@ export interface ISettings {
   listDelimiter: string;
   dateFormat: string;
   processEmptyAssociations: boolean;
+  singleByteEncoding: boolean;
   numThreads: number;
 }


### PR DESCRIPTION
If there are existing CSV files that are not in UTF-8 format, this is
an easy way to flip a switch and load them without first having to
first convert the file to UTF-8 format.

##### Description


##### What did you change?


##### Verify that...

- [x] `npm run lint` passes
- [x] `ng serve` web-only angular app works
- [x] `npm start` debug app works
- [x] `npm run package` installer package works
