### PR TITLE
feat(Results): Saving command line output for viewing later in history

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -128,12 +128,13 @@ export class AppComponent implements OnInit {
   private onDone(text: string): void {
     this.zone.run(() => {
       this.currentRun.output = this.currentRun.output.concat(text);
-      // Wait for final report from results file
+      this.fileService.writeOutputFile(this.currentRun.output);
+      // Wait a second for final report from results file (final file changes can occur just after CLI process exits)
       setTimeout(() => {
         this.fileService.unsubscribe();
         this.dataloaderService.unsubscribe();
         this.sendNotification();
-        this.fileService.getAllRuns(this.onRunData.bind(this));
+        this.fileService.getAllRuns(this.onRunData.bind(this)); // refreshes data
       }, 1000);
     });
   }

--- a/src/app/providers/file/file.service.fakes.ts
+++ b/src/app/providers/file/file.service.fakes.ts
@@ -63,6 +63,7 @@ export class FakePreviewData {
 class Run {
   previewData: IPreviewData = new FakePreviewData();
   results: IResults = new FakeResultsData(this.previewData);
+  output: string = '\nData Loader Sample Output File\n   Total Records: 0\n';
 }
 
 /**


### PR DESCRIPTION
Fixes: https://github.com/bullhorn/dataloader-ui/issues/78

##### Description


##### What did you change?


##### Verify that...

- [ ] `npm run lint` passes
- [ ] `ng serve` web-only angular app works
- [ ] `npm start` debug app works
- [ ] `npm run package` installer package works
