### PR TITLE
fix drag and drop file functionality

### DIFF
--- a/src/app/components/dropzone/dropzone.component.ts
+++ b/src/app/components/dropzone/dropzone.component.ts
@@ -70,7 +70,9 @@ export class DropzoneComponent implements AfterViewInit, OnDestroy {
     event.preventDefault();
     if (DropzoneComponent.isDragFileEvent(event)) {
       const file = event.dataTransfer.files[0];
-      this.onFileProvided(file.path || file.name); // path for electron, name for 'ng serve'
+      const webUtils = window.require && window.require('electron').webUtils;
+      const filePath = webUtils ? webUtils.getPathForFile(file) : file.name;
+      this.onFileProvided(filePath);
       this.dragging = false;
     }
   }

--- a/src/app/components/dropzone/dropzone.component.ts
+++ b/src/app/components/dropzone/dropzone.component.ts
@@ -70,7 +70,7 @@ export class DropzoneComponent implements AfterViewInit, OnDestroy {
     event.preventDefault();
     if (DropzoneComponent.isDragFileEvent(event)) {
       const file = event.dataTransfer.files[0];
-      const webUtils = window.require && window.require('electron').webUtils;
+      const webUtils = window.require?.('electron')?.webUtils;
       const filePath = webUtils ? webUtils.getPathForFile(file) : file.name;
       this.onFileProvided(filePath);
       this.dragging = false;


### PR DESCRIPTION
##### Description
file.path was removed from File objects in Electron 32+. The app is on Electron 37.2.4. When drag-dropping, file.path is undefined, so it falls back to file.name (no directory path). getCsvPreviewData() then can't locate the file and silently returns no headers.

##### What did you change?
Replace file.path with webUtils.getPathForFile(file), which is Electron's replacement API.

##### Verify that...

- [X] `yarn lint` passes
- [X] `yarn test` web-only angular app works
- [X] `yarn start` debug app works
- [X] `yarn package` installer package works
